### PR TITLE
feat: add readonly and print flags

### DIFF
--- a/main_darwin.go
+++ b/main_darwin.go
@@ -2,6 +2,4 @@ package main
 
 const lineBreak = "\n"
 
-func getHostsFile() string {
-	return "/etc/hosts"
-}
+const hostsFile = "/etc/hosts"

--- a/main_linux.go
+++ b/main_linux.go
@@ -2,6 +2,4 @@ package main
 
 const lineBreak = "\n"
 
-func getHostsFile() string {
-	return "/etc/hosts"
-}
+const hostsFile = "/etc/hosts"

--- a/main_windows.go
+++ b/main_windows.go
@@ -4,6 +4,4 @@ import "os"
 
 const lineBreak = "\r\n"
 
-func getHostsFile() string {
-	return os.Getenv("SystemRoot") + `\System32\drivers\etc\hosts`
-}
+const hostsFile = os.Getenv("SystemRoot") + `\System32\drivers\etc\hosts`


### PR DESCRIPTION
Thanks, handy tool!

I wanted to use it in a script that can't run as root, but saw that it was hard-coded to write to the file.

This PR does the following:

* Remove references to now-deprecated `ioutil` and replace with `os`.
* Check all errors and surface the errors back to the `main` function.
* Add new `print` and `update` CLI flags to be able to disable/enable functionality (defaults remain the same). 